### PR TITLE
mastodon.py: Basic code to post to the Mastodon network

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,6 @@ Made by Elad Alfassa.
 Dependencies
 ============
 * tweepy
+* Mastodon.py
 * wordfilter
 * requests

--- a/picdescbot/mastodon.py
+++ b/picdescbot/mastodon.py
@@ -1,0 +1,41 @@
+# coding=utf-8
+# picdescbot: a tiny twitter/tumblr bot that tweets random pictures from wikipedia and their descriptions
+# this file implements Mastodon-related functionality
+# Copyright (C) 2017 Federico Mena Quintero <federico@gnome.org>
+
+# This uses Mastodon.py: https://pypi.python.org/pypi/Mastodon.py/1.0.5
+# Documentation for that: https://mastodonpy.readthedocs.io/en/latest/
+
+from mastodon import Mastodon
+
+class Client(object):
+    name = "mastodon"
+
+    # FIXME: Note how
+    # https://mastodonpy.readthedocs.io/en/latest/#app-registration-and-user-authentication
+    # has the code bit to generate our mastodon-clientcred.txt.  We
+    # don't do this here; do it by hand!
+    #
+    # Mastodon.create_app("picdescbot",
+    #                     scopes       = ["write"],    # no read or follow
+    #                     api_base_url = "https://botsin.space",
+    #                     to_file      = "mastodon-clientcred.txt")
+    #
+
+    def __init__(self, config):
+        # FIXME: pull this out of `config`
+        self.mastodon = Mastodon(client_id = "mastodon-clientcred.txt")
+
+        # FIXME: pull these out of `config`
+        self.access_token = mastodon.log_in("username@example.com",
+                                            "supersecretpassword")
+
+    def send(self, picture):
+        filename = picture.url.split('/')[-1]
+        data = picture.download_picture()
+
+        posted_pic_ids = self.mastodon.media_post (filename)
+
+        self.mastodon.status_post (picture.caption,
+                                   sensitive=True,
+                                   media_ids=posted_pic_ids)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ tweepy
 requests
 wordfilter
 python-tumblpy
+Mastodon.py


### PR DESCRIPTION
This does not create the app token; there is a FIXME with
info on how to do that.

Also, we don't pull the configuration out of the `config` passed to the
Client.  The code uses meaningless values right now.

The send() method does not attempt to retry.